### PR TITLE
Add snake spaces to Resource label

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -42,7 +42,7 @@ abstract class Resource
      */
     public static function label(): string
     {
-        return  Str::of(static::nameWithoutResource())->snake(' ')->title()->plural();
+        return Str::of(static::nameWithoutResource())->snake(' ')->title()->plural();
     }
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -42,7 +42,7 @@ abstract class Resource
      */
     public static function label(): string
     {
-        return Str::plural(static::nameWithoutResource());
+        return  Str::of(static::nameWithoutResource())->snake(' ')->title()->plural();
     }
 
     /**


### PR DESCRIPTION
Example: I have a resource class `class OceanRateImportSchemaResource extends Resource`. On list screen I see a header "OceanRateImportSchemas" - without spaces between words.
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/451007/103129600-6bafcc80-46aa-11eb-9783-20d42bc3d72d.png">

This PR fixes:
<img width="1049" alt="image" src="https://user-images.githubusercontent.com/451007/103129636-8b46f500-46aa-11eb-99d2-62dd281a75a8.png">
