### PR TITLE
Added Preventing Conflicts (Traffic Cop)

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,24 @@ public static function createToastMessage(): string
 
 You can learn more on the [Laravel localization page](https://laravel.com/docs/localization).
 
+
+## Preventing Conflicts (Traffic Cop)
+
+If this option is active, the model will be checked for the last change if it was updated after the edit form was opened. A validation error will be thrown. Feature Traffic Cop is disabled by default.
+
+```php
+/**
+ * Indicates whether should check for modifications between viewing and updating a resource.
+ *
+ * @return  bool
+*/
+public static function trafficCop(): bool
+{
+    return false;
+}
+```
+
+
 ## Backers
 
 Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/orchid#backer)]

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -8,5 +8,6 @@
     "You have successfully deleted the :resource.": "Удаление :resource прошло успешно.",
     "An error has occurred": "Произошла ошибка",
     "Are you sure you want to delete this resource?": "Вы уверены, что хотите удалить этот ресурс?",
-    "Are you sure you want to force delete this resource?": "Вы уверены, что хотите принудительно удалить этот ресурс?"
+    "Are you sure you want to force delete this resource?": "Вы уверены, что хотите принудительно удалить этот ресурс?",
+    "Since the :resource was edited, its values have changed. Refresh the page to see them or click \":button\" again to replace them.": "С момента редактирования :resource его значения изменились. Обновите страницу, чтобы увидеть их, или нажмите «:button» еще раз, чтобы заменить их."
 }

--- a/src/Requests/UpdateRequest.php
+++ b/src/Requests/UpdateRequest.php
@@ -39,7 +39,7 @@ class UpdateRequest extends ResourceRequest
      */
     protected function hasBeenUpdatedSinceRetrieval(): bool
     {
-        if($this->missing('_retrieved_at')) {
+        if ($this->missing('_retrieved_at')) {
             return false;
         }
 

--- a/src/Requests/UpdateRequest.php
+++ b/src/Requests/UpdateRequest.php
@@ -2,6 +2,8 @@
 
 namespace Orchid\Crud\Requests;
 
+use Carbon\Carbon;
+use Orchid\Crud\Resource;
 use Orchid\Crud\ResourceRequest;
 
 class UpdateRequest extends ResourceRequest
@@ -14,5 +16,60 @@ class UpdateRequest extends ResourceRequest
     public function authorize()
     {
         return $this->can('update');
+    }
+
+    /**
+     * Validate the class instance.
+     *
+     * @return void
+     */
+    protected function prepareForValidation(): void
+    {
+        parent::prepareForValidation();
+
+        if ($this->hasBeenUpdatedSinceRetrieval()) {
+            $this->redirectWithTrafficCop();
+        }
+    }
+
+    /**
+     * Determine if the model has been updated since it was retrieved.
+     *
+     * @return bool
+     */
+    protected function hasBeenUpdatedSinceRetrieval(): bool
+    {
+        if($this->missing('_retrieved_at')) {
+            return false;
+        }
+
+        /** @var Resource $resource */
+        $resource = $this->resource();
+
+        // Check to see whether Traffic Cop is enabled for this resource...
+        if ($resource::trafficCop() === false) {
+            return false;
+        }
+
+        $model = $this->findModelOrFail();
+        $column = $model->getUpdatedAtColumn();
+
+        if (! $model->{$column}) {
+            return false;
+        }
+
+        return $model->{$column}->gt(Carbon::parse($this->input('_retrieved_at')));
+    }
+
+    /**
+     * Return the user back page with an error
+     */
+    protected function redirectWithTrafficCop(): void
+    {
+        $back = back()
+            ->withErrors($this->resource()->trafficCopMessage())
+            ->withInput();
+
+        abort($back);
     }
 }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -268,7 +268,7 @@ abstract class Resource
     /**
      * Indicates whether should check for modifications between viewing and updating a resource.
      *
-     * @return  bool
+     * @return bool
      */
     public static function trafficCop(): bool
     {

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -201,6 +201,19 @@ abstract class Resource
     }
 
     /**
+     * Get the text for Traffic Cop error.
+     *
+     * @return string
+     */
+    public static function trafficCopMessage(): string
+    {
+        return __('Since the :resource was edited, its values have changed. Refresh the page to see them or click ":button" again to replace them.', [
+            'resource' => static::singularLabel(),
+            'button'   => self::updateButtonLabel(),
+        ]);
+    }
+
+    /**
      * Get the validation rules that apply to save/update.
      *
      * @param Model $model
@@ -250,6 +263,16 @@ abstract class Resource
     public function with(): array
     {
         return [];
+    }
+
+    /**
+     * Indicates whether should check for modifications between viewing and updating a resource.
+     *
+     * @return  bool
+     */
+    public static function trafficCop(): bool
+    {
+        return false;
     }
 
     /**

--- a/src/Screens/EditScreen.php
+++ b/src/Screens/EditScreen.php
@@ -49,7 +49,10 @@ class EditScreen extends CrudScreen
             Button::make($this->resource::updateButtonLabel())
                 ->canSee($this->request->can('update'))
                 ->method('update')
-                ->icon('check'),
+                ->icon('check')
+                ->parameters([
+                    '_retrieved_at' => optional($this->model->{$this->model->getUpdatedAtColumn()})->toJson(),
+                ]),
 
             Button::make($this->resource::deleteButtonLabel())
                 ->novalidate()

--- a/tests/Fixtures/PostResource.php
+++ b/tests/Fixtures/PostResource.php
@@ -61,6 +61,16 @@ class PostResource extends Resource
     }
 
     /**
+     * Indicates whether should check for modifications between viewing and updating a resource.
+     *
+     * @return  bool
+     */
+    public static function trafficCop(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get the validation rules that apply to save/update.
      *
      * @param Model $model

--- a/tests/Fixtures/PostResource.php
+++ b/tests/Fixtures/PostResource.php
@@ -63,7 +63,7 @@ class PostResource extends Resource
     /**
      * Indicates whether should check for modifications between viewing and updating a resource.
      *
-     * @return  bool
+     * @return bool
      */
     public static function trafficCop(): bool
     {

--- a/tests/TrafficCopTest.php
+++ b/tests/TrafficCopTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orchid\Crud\Tests;
+
+use Orchid\Crud\Tests\Fixtures\PostResource;
+use Orchid\Crud\Tests\Models\Post;
+
+class TrafficCopTest extends TestCase
+{
+    public function testBaseCopResource(): void
+    {
+        $post = Post::factory()->create();
+        $post->touch();
+        $retrievedAt = $post->updated_at->subMinutes(5)->toJson();
+
+        $this
+            ->followingRedirects()
+            ->from(route('platform.resource.edit', [
+                'resource' => PostResource::uriKey(),
+                'id'       => $post,
+            ]))
+            ->post(route('platform.resource.edit', [
+                'resource' => PostResource::uriKey(),
+                'id'       => $post,
+                'method'   => 'update',
+            ]), [
+                'model'         => $post->toArray(),
+                '_retrieved_at' => $retrievedAt,
+            ])
+            ->assertSee(PostResource::trafficCopMessage())
+            ->assertOk();
+    }
+
+    /**
+     * Set the URL of the previous request.
+     *
+     * @param  string  $url
+     * @return $this
+     */
+    public function from(string $url)
+    {
+        session()->setPreviousUrl($url);
+
+        return $this;
+    }
+
+}

--- a/tests/TrafficCopTest.php
+++ b/tests/TrafficCopTest.php
@@ -34,7 +34,8 @@ class TrafficCopTest extends TestCase
     /**
      * Set the URL of the previous request.
      *
-     * @param  string  $url
+     * @param string $url
+     *
      * @return $this
      */
     public function from(string $url)
@@ -43,5 +44,4 @@ class TrafficCopTest extends TestCase
 
         return $this;
     }
-
 }


### PR DESCRIPTION
## Preventing Conflicts (Traffic Cop)

If this option is active, the model will be checked for the last change if it was updated after the edit form was opened. A validation error will be thrown. Feature Traffic Cop is disabled by default.

```php
/**
 * Indicates whether should check for modifications between viewing and updating a resource.
 *
 * @return  bool
*/
public static function trafficCop(): bool
{
    return false;
}
```