### PR TITLE
Resource pagination

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -29,6 +29,17 @@ abstract class Resource
     }
 
     /**
+     * Get the number of models to return per page
+     *
+     * @return int
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public static function perPage(): int
+    {
+        return app()->make(static::$model)->getPerPage();
+    }
+
+    /**
      * Get the displayable icon of the resource.
      *
      * @return string

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -31,8 +31,9 @@ abstract class Resource
     /**
      * Get the number of models to return per page
      *
-     * @return int
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return int
      */
     public static function perPage(): int
     {

--- a/src/ResourceRequest.php
+++ b/src/ResourceRequest.php
@@ -136,7 +136,7 @@ class ResourceRequest extends FormRequest
             ->with($this->resource()->with())
             ->filters()
             ->filtersApply($this->resource()->filters())
-            ->paginate();
+            ->paginate($this->resource()->perPage());
     }
 
     /**

--- a/tests/Fixtures/PaginationResource.php
+++ b/tests/Fixtures/PaginationResource.php
@@ -7,8 +7,9 @@ class PaginationResource extends PostResource
     /**
      * Get the number of models to return per page
      *
-     * @return int
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     *
+     * @return int
      */
     public static function perPage(): int
     {

--- a/tests/Fixtures/PaginationResource.php
+++ b/tests/Fixtures/PaginationResource.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Orchid\Crud\Tests\Fixtures;
+
+class PaginationResource extends PostResource
+{
+    /**
+     * Get the number of models to return per page
+     *
+     * @return int
+     * @throws \Illuminate\Contracts\Container\BindingResolutionException
+     */
+    public static function perPage(): int
+    {
+        return 3;
+    }
+}

--- a/tests/Fixtures/PrivateResource.php
+++ b/tests/Fixtures/PrivateResource.php
@@ -2,20 +2,8 @@
 
 namespace Orchid\Crud\Tests\Fixtures;
 
-use Orchid\Crud\Resource;
-use Orchid\Crud\Tests\Models\Post;
-use Orchid\Screen\Field;
-use Orchid\Screen\TD;
-
-class PrivateResource extends Resource
+class PrivateResource extends PostResource
 {
-    /**
-     * The model the resource corresponds to.
-     *
-     * @var string
-     */
-    public static $model = Post::class;
-
     /**
      * Get the permission key for the resource.
      *
@@ -24,21 +12,5 @@ class PrivateResource extends Resource
     public static function permission(): ?string
     {
         return 'private-resource';
-    }
-
-    /**
-     * @return TD[]
-     */
-    public function columns(): array
-    {
-        return [];
-    }
-
-    /**
-     * @return Field[]
-     */
-    public function fields(): array
-    {
-        return [];
     }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -11,10 +11,7 @@ use Orchid\Screen\AsSource;
 
 class Post extends Model
 {
-    use HasFactory;
-    use AsSource;
-    use Filterable;
-    use Attachable;
+    use HasFactory, AsSource, Filterable, Attachable;
 
     /**
      * Create a new factory instance for the model.

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -11,7 +11,10 @@ use Orchid\Screen\AsSource;
 
 class Post extends Model
 {
-    use HasFactory, AsSource, Filterable, Attachable;
+    use HasFactory;
+    use AsSource;
+    use Filterable;
+    use Attachable;
 
     /**
      * Create a new factory instance for the model.

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Orchid\Crud\Tests;
+
+use Orchid\Crud\Tests\Fixtures\PaginationResource;
+use Orchid\Crud\Tests\Models\Post;
+
+class PaginationTest extends TestCase
+{
+    /**
+     * @var Post[]
+     */
+    protected $posts;
+
+    /**
+     *
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->posts = Post::factory()->count(4)->create();
+    }
+
+    /**
+     *
+     */
+    public function testListResource(): void
+    {
+        $response = $this->get(route('platform.resource.list', [
+            'resource' => PaginationResource::uriKey(),
+        ]));
+
+
+        $this->posts->take(3)->each(function (Post $post) use ($response) {
+            $response->assertSeeText($post->description);
+        });
+
+        $response->assertDontSeeText( $this->posts->last()->description);
+    }
+}

--- a/tests/PaginationTest.php
+++ b/tests/PaginationTest.php
@@ -36,6 +36,6 @@ class PaginationTest extends TestCase
             $response->assertSeeText($post->description);
         });
 
-        $response->assertDontSeeText( $this->posts->last()->description);
+        $response->assertDontSeeText($this->posts->last()->description);
     }
 }


### PR DESCRIPTION
## Results per page

To define how many results should be shown per page on the index, set the `perPage` method:

```php
/**
 * Get the number of models to return per page
 *
 * @return int
 * @throws \Illuminate\Contracts\Container\BindingResolutionException
 */
public static function perPage(): int
{
    return app()->make(static::$model)->getPerPage();
}
```