### PR TITLE
refs #14 Added method for hidden resource in navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `crud` will be documented in this file
 
+## 2.5.0 - 2021-01-11
+
+### Added
+- Method for hidden resource in navigation [#16](https://github.com/orchidsoftware/crud/pull/16)
+
 ## 2.4.0 - 2021-01-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,6 +199,23 @@ public function filters(): array
 
 You can learn more on the Orchid [filtration page](https://orchid.software/en/docs/filters/#eloquent-filter).
 
+## Navigation
+
+If you do not want a resource to appear in the navigation, you may override the `displayInNavigation` method of your resource class:
+
+```php
+/**
+ * Get the resource should be displayed in the navigation
+ *
+ * @return bool
+ */
+public static function displayInNavigation(): bool
+{
+    return false;
+}
+```
+
+
 ## Eager Loading
 
 Suppose you routinely need to access a resource's relationships within your fields. In that case, it may be a good idea to add the relationship to the `with` property of your resource. This property instructs to always eager to load the listed relationships when retrieving the resource.

--- a/src/Arbitrator.php
+++ b/src/Arbitrator.php
@@ -93,6 +93,10 @@ class Arbitrator
      */
     private function registerMenu(Resource $resource, int $key): Arbitrator
     {
+        if (!$resource::displayInNavigation()) {
+            return $this;
+        }
+
         Dashboard::menu()->add(
             Menu::MAIN,
             ItemMenu::label($resource::label())

--- a/src/Arbitrator.php
+++ b/src/Arbitrator.php
@@ -93,7 +93,7 @@ class Arbitrator
      */
     private function registerMenu(Resource $resource, int $key): Arbitrator
     {
-        if (!$resource::displayInNavigation()) {
+        if (! $resource::displayInNavigation()) {
             return $this;
         }
 

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -29,6 +29,16 @@ abstract class Resource
     }
 
     /**
+     * Get the resource should be displayed in the navigation
+     *
+     * @return bool
+     */
+    public static function displayInNavigation(): bool
+    {
+        return true;
+    }
+
+    /**
      * Get the number of models to return per page
      *
      * @throws \Illuminate\Contracts\Container\BindingResolutionException

--- a/tests/Fixtures/NoDisplayInNavigationResource.php
+++ b/tests/Fixtures/NoDisplayInNavigationResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orchid\Crud\Tests\Fixtures;
+
+class NoDisplayInNavigationResource extends PostResource
+{
+    /**
+     * Get the resource should be displayed in the navigation
+     *
+     * @return bool
+     */
+    public static function displayInNavigation(): bool
+    {
+        return false;
+    }
+}

--- a/tests/NavigationTest.php
+++ b/tests/NavigationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+
+namespace Orchid\Crud\Tests;
+
+use Orchid\Crud\Tests\Fixtures\NoDisplayInNavigationResource;
+use Orchid\Crud\Tests\Fixtures\PostResource;
+
+class NavigationTest extends TestCase
+{
+    /**
+     *
+     */
+    public function testNoDisplayResourceInNavigation(): void
+    {
+        $this->get(route('platform.resource.list', [
+            'resource' => PostResource::uriKey(),
+        ]))
+            ->assertSee(PostResource::singularLabel())
+            ->assertDontSee(NoDisplayInNavigationResource::singularLabel())
+            ->assertOk();
+    }
+}


### PR DESCRIPTION
If you do not want a resource to appear in the navigation, you may override the `displayInNavigation` method of your resource class:

```php
/**
 * Get the resource should be displayed in the navigation
 *
 * @return bool
 */
public static function displayInNavigation(): bool
{
    return false;
}
```