### PR TITLE
Do not use the `Model` prefix for transmitted data

### DIFF
--- a/src/CrudScreen.php
+++ b/src/CrudScreen.php
@@ -74,8 +74,6 @@ abstract class CrudScreen extends Screen
      */
     public function fields()
     {
-        return array_map(function (Field $field) {
-            return $field->set('name', 'model.' . $field->get('name'));
-        }, $this->resource->fields());
+        return $this->resource->fields();
     }
 }

--- a/src/ResourceRequest.php
+++ b/src/ResourceRequest.php
@@ -6,7 +6,6 @@ use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 

--- a/src/ResourceRequest.php
+++ b/src/ResourceRequest.php
@@ -22,13 +22,8 @@ class ResourceRequest extends FormRequest
         }
 
         $model = $this->findModel() ?? $this->resource()->getModel();
-        $rules = $this->resource()->rules($model);
 
-        return collect($rules)
-            ->mapWithKeys(function ($value, $key) {
-                return ['model.' . $key => $value];
-            })
-            ->toArray();
+        return $this->resource()->rules($model);
     }
 
     /**
@@ -40,7 +35,7 @@ class ResourceRequest extends FormRequest
     {
         return collect($this->model)->keys()
             ->mapWithKeys(function ($key) {
-                return ['model.' . $key => $key];
+                return [$key => $key];
             })
             ->merge($this->resource()->attributes())
             ->toArray();
@@ -72,8 +67,6 @@ class ResourceRequest extends FormRequest
      */
     public function withValidator()
     {
-        $data = Arr::wrap($this->model);
-
         // Remove private parameters (Start with '_')
         collect($this->query->all())
             ->keys()
@@ -83,13 +76,14 @@ class ResourceRequest extends FormRequest
                 $this->query->remove($key);
             });
 
+        // Remove private parameters (Start with '_')
         collect($this->all())
             ->keys()
-            ->each(function (string $key) {
+            ->filter(function (string $key) {
+                return Str::startsWith($key, '_');
+            })->each(function (string $key) {
                 $this->offsetUnset($key);
             });
-
-        $this->replace($data);
     }
 
     /**

--- a/src/Screens/CreateScreen.php
+++ b/src/Screens/CreateScreen.php
@@ -21,9 +21,7 @@ class CreateScreen extends CrudScreen
      */
     public function query(CreateRequest $request): array
     {
-        return [
-            'model' => $request->model(),
-        ];
+        return $request->model()->toArray();
     }
 
     /**

--- a/src/Screens/EditScreen.php
+++ b/src/Screens/EditScreen.php
@@ -33,9 +33,7 @@ class EditScreen extends CrudScreen
     {
         $this->model = $request->findModelOrFail();
 
-        return [
-            'model' => $this->model,
-        ];
+        return $this->model->toArray();
     }
 
     /**

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -22,7 +22,7 @@ class ListScreen extends CrudScreen
     public function query(IndexRequest $request): array
     {
         return [
-            'model' => $request->getModelPaginationList(),
+            'models' => $request->getModelPaginationList(),
         ];
     }
 
@@ -64,7 +64,7 @@ class ListScreen extends CrudScreen
 
         return [
             Layout::selection($this->resource->filters()),
-            Layout::table('model', $grid),
+            Layout::table('models', $grid),
         ];
     }
 }

--- a/tests/CrudTest.php
+++ b/tests/CrudTest.php
@@ -63,9 +63,7 @@ class CrudTest extends TestCase
             ->post(route('platform.resource.create', [
                 'resource' => PostResource::uriKey(),
                 'method'   => 'save',
-            ]), [
-                'model' => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertSee(PostResource::createToastMessage())
             ->assertOk();
 
@@ -94,9 +92,7 @@ class CrudTest extends TestCase
             ->post(route('platform.resource.create', [
                 'resource' => PostResource::uriKey(),
                 'method'   => 'save',
-            ]), [
-                'model' => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertSee(PostResource::createToastMessage())
             ->assertOk();
 
@@ -109,9 +105,7 @@ class CrudTest extends TestCase
             ->post(route('platform.resource.create', [
                 'resource' => PostResource::uriKey(),
                 'method'   => 'save',
-            ]), [
-                'model' => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertSee('The title has already been taken.')
             ->assertSee('Change a few things up and try submitting again.')
             ->assertOk();
@@ -150,9 +144,7 @@ class CrudTest extends TestCase
                 'resource' => PostResource::uriKey(),
                 'id'       => $post,
                 'method'   => 'update',
-            ]), [
-                'model' => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertSee(PostResource::updateToastMessage())
             ->assertOk();
 

--- a/tests/TrafficCopTest.php
+++ b/tests/TrafficCopTest.php
@@ -24,9 +24,7 @@ class TrafficCopTest extends TestCase
                 'id'            => $post,
                 'method'        => 'update',
                 '_retrieved_at' => $retrievedAt,
-            ]), [
-                'model'         => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertSee(PostResource::trafficCopMessage())
             ->assertOk();
     }
@@ -44,9 +42,7 @@ class TrafficCopTest extends TestCase
                 'id'            => $post,
                 'method'        => 'update',
                 '_retrieved_at' => $retrievedAt,
-            ]), [
-                'model'         => $post->toArray(),
-            ])
+            ]), $post->toArray())
             ->assertDontSee(PostResource::trafficCopMessage())
             ->assertOk();
     }


### PR DESCRIPTION
Removes the prefix's use for binding and sending model values since there are more minuses from this than pluses. 
Along the way, this solves problem #15