### PR TITLE
Bulk Actions

### DIFF
--- a/src/Action.php
+++ b/src/Action.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Orchid\Crud;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Orchid\Screen\Actions\Button;
+
+abstract class Action
+{
+    /**
+     * The button of the action.
+     *
+     * @return Button
+     */
+    abstract public function button(): Button;
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param \Illuminate\Support\Collection $models
+     */
+    abstract public function handle(Collection $models);
+
+    /**
+     * Unique method string to use in the request
+     *
+     * @return string
+     */
+    public function name(): string
+    {
+        return Str::of(static::class)->replace('\\', '-')->slug();
+    }
+}

--- a/src/Action.php
+++ b/src/Action.php
@@ -27,7 +27,7 @@ abstract class Action
      *
      * @return string
      */
-    public function name(): string
+    public static function name(): string
     {
         return Str::of(static::class)->replace('\\', '-')->slug();
     }

--- a/src/Commands/ActionCommand.php
+++ b/src/Commands/ActionCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Orchid\Crud\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+
+class ActionCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'orchid:action';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new action class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Action';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub(): string
+    {
+        return __DIR__.'/../../stubs/action.stub';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     *
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        return $rootNamespace.'\Orchid\Actions';
+    }
+}

--- a/src/CrudScreen.php
+++ b/src/CrudScreen.php
@@ -103,7 +103,7 @@ abstract class CrudScreen extends Screen
     protected function actions(): Collection
     {
         return collect($this->resource->actions())->map(function ($action){
-           return is_string($action) ? app()->make($action) : $action;
+           return is_string($action) ? resolve($action) : $action;
         });
     }
 

--- a/src/CrudScreen.php
+++ b/src/CrudScreen.php
@@ -116,8 +116,8 @@ abstract class CrudScreen extends Screen
      */
     protected function actions(): Collection
     {
-        return collect($this->resource->actions())->map(function ($action){
-           return is_string($action) ? resolve($action) : $action;
+        return collect($this->resource->actions())->map(function ($action) {
+            return is_string($action) ? resolve($action) : $action;
         });
     }
 
@@ -146,5 +146,4 @@ abstract class CrudScreen extends Screen
 
         return $action->handle($request->models());
     }
-
 }

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -4,6 +4,7 @@ namespace Orchid\Crud;
 
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
+use Orchid\Crud\Commands\ActionCommand;
 use Orchid\Crud\Commands\ResourceCommand;
 use Orchid\Crud\Middleware\BootCrudGenerator;
 use Orchid\Platform\Providers\FoundationServiceProvider;
@@ -25,6 +26,7 @@ class CrudServiceProvider extends ServiceProvider
      */
     protected $commands = [
         ResourceCommand::class,
+        ActionCommand::class,
     ];
 
     /**

--- a/src/Requests/ActionRequest.php
+++ b/src/Requests/ActionRequest.php
@@ -13,7 +13,7 @@ class ActionRequest extends ResourceRequest
     public function rules()
     {
         return  [
-            '_action' => 'required'
+            '_action' => 'required',
         ];
     }
 

--- a/src/Requests/ActionRequest.php
+++ b/src/Requests/ActionRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Orchid\Crud\Requests;
+
+use Illuminate\Support\Collection;
+use Orchid\Crud\ResourceRequest;
+
+class ActionRequest extends ResourceRequest
+{
+    /**
+     * @return array
+     */
+    public function rules()
+    {
+        return  [
+            '_action' => 'required'
+        ];
+    }
+
+    /**
+     * Configure the validator instance.
+     *
+     * @return void
+     */
+    public function withValidator()
+    {
+        return null;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function models(): Collection
+    {
+        $models = collect();
+
+        if ($this->has('_models')) {
+            $models = $this->model()->whereIn(
+                $this->model()->getKeyName(),
+                $this->get('_models')
+            )->get();
+        }
+
+        $current = $this->findModel();
+
+        if ($current !== null) {
+            $models = collect($current);
+        }
+
+        return $models;
+    }
+}

--- a/src/Requests/CreateRequest.php
+++ b/src/Requests/CreateRequest.php
@@ -2,6 +2,7 @@
 
 namespace Orchid\Crud\Requests;
 
+use Orchid\Crud\Layouts\ResourceFields;
 use Orchid\Crud\ResourceRequest;
 
 class CreateRequest extends ResourceRequest
@@ -14,5 +15,24 @@ class CreateRequest extends ResourceRequest
     public function authorize()
     {
         return $this->can('create');
+    }
+
+    /**
+     * @return array
+     */
+    public function rules()
+    {
+        if ($this->method() === 'GET') {
+            return [];
+        }
+
+        $model = $this->findModel() ?? $this->resource()->getModel();
+        $rules = $this->resource()->rules($model);
+
+        return collect($rules)
+            ->mapWithKeys(function ($value, $key) {
+                return [ResourceFields::PREFIX . '.' . $key => $value];
+            })
+            ->toArray();
     }
 }

--- a/src/Requests/UpdateRequest.php
+++ b/src/Requests/UpdateRequest.php
@@ -3,9 +3,7 @@
 namespace Orchid\Crud\Requests;
 
 use Carbon\Carbon;
-use Orchid\Crud\Layouts\ResourceFields;
 use Orchid\Crud\Resource;
-use Orchid\Crud\ResourceRequest;
 
 class UpdateRequest extends CreateRequest
 {

--- a/src/Requests/UpdateRequest.php
+++ b/src/Requests/UpdateRequest.php
@@ -3,10 +3,11 @@
 namespace Orchid\Crud\Requests;
 
 use Carbon\Carbon;
+use Orchid\Crud\Layouts\ResourceFields;
 use Orchid\Crud\Resource;
 use Orchid\Crud\ResourceRequest;
 
-class UpdateRequest extends ResourceRequest
+class UpdateRequest extends CreateRequest
 {
     /**
      * Determine if the user is authorized to make this request.

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -276,6 +276,16 @@ abstract class Resource
     }
 
     /**
+     * Get the text when there are no resources for the action.
+     *
+     * @return string
+     */
+    public static function emptyResourceForAction(): string
+    {
+        return __('No ":resources" over which you can perform an action', ['resources' => static::label()]);
+    }
+
+    /**
      * Get the validation rules that apply to save/update.
      *
      * @param Model $model

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -47,7 +47,7 @@ abstract class Resource
      */
     public static function perPage(): int
     {
-        return app()->make(static::$model)->getPerPage();
+        return resolve(static::$model)->getPerPage();
     }
 
     /**

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -328,6 +328,16 @@ abstract class Resource
     }
 
     /**
+     * Get the actions available for the resource.
+     *
+     * @return array
+     */
+    public function actions(): array
+    {
+        return [];
+    }
+
+    /**
      * Indicates whether should check for modifications between viewing and updating a resource.
      *
      * @return bool

--- a/src/ResourceRequest.php
+++ b/src/ResourceRequest.php
@@ -18,18 +18,7 @@ class ResourceRequest extends FormRequest
      */
     public function rules()
     {
-        if ($this->method() === 'GET' || Str::endsWith($this->url(), 'delete')) {
-            return [];
-        }
-
-        $model = $this->findModel() ?? $this->resource()->getModel();
-        $rules = $this->resource()->rules($model);
-
-        return collect($rules)
-            ->mapWithKeys(function ($value, $key) {
-                return [ResourceFields::PREFIX . '.' . $key => $value];
-            })
-            ->toArray();
+        return  [];
     }
 
     /**

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -7,6 +7,7 @@ use Orchid\Crud\CrudScreen;
 use Orchid\Crud\Requests\IndexRequest;
 use Orchid\Screen\Action;
 use Orchid\Screen\Actions\Link;
+use Orchid\Screen\Fields\CheckBox;
 use Orchid\Screen\TD;
 use Orchid\Support\Facades\Layout;
 
@@ -34,6 +35,7 @@ class ListScreen extends CrudScreen
     public function commandBar(): array
     {
         return [
+            $this->actionsButtons(),
             Link::make($this->resource::createButtonLabel())
                 ->route('platform.resource.create', $this->resource::uriKey())
                 ->icon('plus'),
@@ -47,9 +49,17 @@ class ListScreen extends CrudScreen
      */
     public function layout(): array
     {
-        $grid = $this->resource->columns();
+        $grid = collect($this->resource->columns());
 
-        $grid[] = TD::make(__('Actions'))
+        $grid->prepend(TD::make()
+            ->width(50)
+            ->render(function (Model $model) {
+                return CheckBox::make('_models[]')
+                    ->value($model->getKey())
+                    ->checked(false);
+            }));
+
+        $grid->push(TD::make(__('Actions'))
             ->align(TD::ALIGN_RIGHT)
             ->cantHide()
             ->canSee($this->can('update'))
@@ -60,11 +70,11 @@ class ListScreen extends CrudScreen
                         $this->resource::uriKey(),
                         $model->getAttribute($model->getKeyName()),
                     ]);
-            });
+            }));
 
         return [
             Layout::selection($this->resource->filters()),
-            Layout::table('model', $grid),
+            Layout::table('model', $grid->toArray()),
         ];
     }
 }

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -53,6 +53,7 @@ class ListScreen extends CrudScreen
 
         $grid->prepend(TD::make()
             ->width(50)
+            ->canSee($this->availableActions()->isNotEmpty())
             ->render(function (Model $model) {
                 return CheckBox::make('_models[]')
                     ->value($model->getKey())

--- a/stubs/action.stub
+++ b/stubs/action.stub
@@ -1,0 +1,35 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\Collection;
+use Orchid\Crud\Action;
+use Orchid\Screen\Actions\Button;
+use Orchid\Support\Facades\Toast;
+
+class {{ class }} extends Action
+{
+    /**
+     * The button of the action.
+     *
+     * @return Button
+     */
+    public function button(): Button
+    {
+        return Button::make('Run Action')->icon('fire');
+    }
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param \Illuminate\Support\Collection $models
+     */
+    public function handle(Collection $models)
+    {
+        $models->each(function () {
+            // action
+        });
+
+        Toast::message('It worked!');
+    }
+}

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Orchid\Crud\Tests;
+
+use Orchid\Crud\Tests\Fixtures\CustomAction;
+use Orchid\Crud\Tests\Fixtures\PostActionResource;
+use Orchid\Crud\Tests\Fixtures\PostNoActionResource;
+use Orchid\Crud\Tests\Models\Post;
+use Orchid\Screen\Fields\CheckBox;
+
+class ActionTest extends TestCase
+{
+    /**
+     * @var Post[]
+     */
+    protected $posts;
+
+    /**
+     * @var CheckBox
+     */
+    protected $checkbox;
+
+    /**
+     *
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->posts = Post::factory()->count(5)->create();
+
+        $this->checkbox = CheckBox::make('_models[]')
+            ->value($this->posts->first()->getKey())
+            ->checked(false);
+    }
+
+    public function testShowActionOnListResource(): void
+    {
+        $this->get(route('platform.resource.list', [
+            'resource' => PostActionResource::uriKey(),
+        ]))
+            ->assertSee('Run Action')
+            ->assertSee($this->checkbox, false)
+            ->assertOk();
+    }
+
+    public function testDontShowActionOnListResource(): void
+    {
+        $this->get(route('platform.resource.list', [
+            'resource' => PostNoActionResource::uriKey(),
+        ]))
+            ->assertDontSee('Run Action')
+            ->assertDontSee($this->checkbox, false)
+            ->assertOk();
+    }
+
+    public function testRunActionWithEmptyResource():void
+    {
+        $this
+            ->from(route('platform.resource.list', [
+                'resource' => PostActionResource::uriKey(),
+            ]))
+            ->followingRedirects()
+            ->post(route('platform.resource.list', [
+                'resource' => PostActionResource::uriKey(),
+                'method'   => 'action',
+                '_action'   => CustomAction::name(),
+            ]))
+            ->assertSee(PostActionResource::emptyResourceForAction())
+            ->assertOk();
+    }
+
+    public function testRunActionWithResource():void
+    {
+        $this
+            ->from(route('platform.resource.list', [
+                'resource' => PostActionResource::uriKey(),
+            ]))
+            ->followingRedirects()
+            ->post(route('platform.resource.list', [
+                'resource' => PostActionResource::uriKey(),
+                'method'   => 'action',
+                '_action'  => CustomAction::name(),
+                '_models'  => $this->posts->map->getKey()->toArray(),
+            ]))
+            ->assertSee('It worked')
+            ->assertOk();
+    }
+}

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -62,8 +62,8 @@ class ActionTest extends TestCase
             ]))
             ->followingRedirects()
             ->post(route('platform.resource.list', [
-                'resource' => PostActionResource::uriKey(),
-                'method'   => 'action',
+                'resource'  => PostActionResource::uriKey(),
+                'method'    => 'action',
                 '_action'   => CustomAction::name(),
             ]))
             ->assertSee(PostActionResource::emptyResourceForAction())

--- a/tests/Fixtures/CustomAction.php
+++ b/tests/Fixtures/CustomAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Orchid\Crud\Tests\Fixtures;
+
+use Illuminate\Support\Collection;
+use Orchid\Crud\Action;
+use Orchid\Screen\Actions\Button;
+use Orchid\Support\Facades\Toast;
+
+class CustomAction extends Action
+{
+    /**
+     * The button of the action.
+     *
+     * @return Button
+     */
+    public function button(): Button
+    {
+        return Button::make('Run Action')->icon('fire');
+    }
+
+    /**
+     * Perform the action on the given models.
+     *
+     * @param \Illuminate\Support\Collection $models
+     */
+    public function handle(Collection $models)
+    {
+        $models->each(function () {
+            // action
+        });
+
+        Toast::message('It worked!');
+    }
+}

--- a/tests/Fixtures/PostActionResource.php
+++ b/tests/Fixtures/PostActionResource.php
@@ -11,7 +11,7 @@ class PostActionResource extends PostResource
      */
     public function actions(): array
     {
-       return [
+        return [
            CustomAction::class,
        ];
     }

--- a/tests/Fixtures/PostActionResource.php
+++ b/tests/Fixtures/PostActionResource.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Orchid\Crud\Tests\Fixtures;
+
+class PostActionResource extends PostResource
+{
+    /**
+     * Get the actions available for the resource.
+     *
+     * @return array
+     */
+    public function actions(): array
+    {
+       return [
+           CustomAction::class,
+       ];
+    }
+}

--- a/tests/Fixtures/PostNoActionResource.php
+++ b/tests/Fixtures/PostNoActionResource.php
@@ -11,6 +11,6 @@ class PostNoActionResource extends PostResource
      */
     public function actions(): array
     {
-       return [];
+        return [];
     }
 }

--- a/tests/Fixtures/PostNoActionResource.php
+++ b/tests/Fixtures/PostNoActionResource.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Orchid\Crud\Tests\Fixtures;
+
+class PostNoActionResource extends PostResource
+{
+    /**
+     * Get the actions available for the resource.
+     *
+     * @return array
+     */
+    public function actions(): array
+    {
+       return [];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -105,4 +105,18 @@ class TestCase extends Orchestra
             'Dashboard'   => Dashboard::class,
         ];
     }
+
+    /**
+     * Set the URL of the previous request.
+     *
+     * @param string $url
+     *
+     * @return $this
+     */
+    public function from(string $url)
+    {
+        session()->setPreviousUrl($url);
+
+        return $this;
+    }
 }

--- a/tests/TrafficCopTest.php
+++ b/tests/TrafficCopTest.php
@@ -50,18 +50,4 @@ class TrafficCopTest extends TestCase
             ->assertDontSee(PostResource::trafficCopMessage())
             ->assertOk();
     }
-
-    /**
-     * Set the URL of the previous request.
-     *
-     * @param string $url
-     *
-     * @return $this
-     */
-    public function from(string $url)
-    {
-        session()->setPreviousUrl($url);
-
-        return $this;
-    }
 }


### PR DESCRIPTION
## Introduction

As mentioned [here](https://github.com/orchidsoftware/platform/discussions/1468), it would be great to have action and bulk action for the CRUD. This PR is aimed at implementing such an idea. We already have examples of such an implementation in similar projects (https://litstack.io/docs/3.x/crud/actions and https://nova.laravel.com/docs/3.0/actions/defining-actions.html)

![image](https://user-images.githubusercontent.com/5102591/104929436-ee2f6180-59b4-11eb-9b2c-8af2670682ed.png)



## Proposed change

Actions may be generated using the `orchid:action` Artisan command:

```bash
php artisan orchid:action CustomAction
```
By default, all actions are placed in the `app/Orchid/Actions` directory.


The action necessarily consists of two methods. Method `button` defines name, icon, dialog box, etc. And the `handler` method directly handles the action with the models.

```php
namespace App\Orchid\Actions;

use Illuminate\Support\Collection;
use Orchid\Crud\Action;
use Orchid\Screen\Actions\Button;
use Orchid\Support\Facades\Toast;

class CustomAction extends Action
{
    /**
     * The button of the action.
     *
     * @return Button
     */
    public function button(): Button
    {
        return Button::make('Run Custom Action')->icon('fire');
    }

    /**
     * Perform the action on the given models.
     *
     * @param \Illuminate\Support\Collection $models
     */
    public function handle(Collection $models)
    {
        $models->each(function () {
            // action
        });

        Toast::message('It worked!');
    }
}

```

Within the `handle` method, you may perform whatever tasks are necessary to complete the action.

> The handle method always receives a `Collection` of models, even if the action is only being performed against a single model.


Once you have defined an action, you are ready to attach it to a resource. Each resource contains an actions method. To attach an action to a resource, you should add it to the array of actions returned by this method:

```php
/**
 * Get the actions available for the resource.
 *
 * @return array
 */
public function actions(): array
{
    return [
        CustomAction::class,
    ];
}
```