### PR TITLE
Add method hide actions

### DIFF
--- a/src/Resource.php
+++ b/src/Resource.php
@@ -480,11 +480,11 @@ abstract class Resource
     }
 
     /**
-     * Should add actions?
+     * Determines whether the actions block should be shown in the table.
      *
      * @return bool
      */
-    public function isAddActions(): bool
+    public function canShowTableActions(): bool
     {
         return true;
     }

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -478,4 +478,14 @@ abstract class Resource
 
         $model->forceDelete();
     }
+
+    /**
+     * Should add actions?
+     *
+     * @return bool
+     */
+    public function isAddActions(): bool
+    {
+        return true;
+    }
 }

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -63,7 +63,7 @@ class ListScreen extends CrudScreen
                     ->checked(false);
             }));
 
-        if($this->resource->isAddActions()){
+        if($this->resource->canShowTableActions()){
             $grid->push(TD::make(__('Actions'))
                 ->alignRight()
                 ->cantHide()

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -63,15 +63,17 @@ class ListScreen extends CrudScreen
                     ->checked(false);
             }));
 
-        $grid->push(TD::make(__('Actions'))
-            ->alignRight()
-            ->cantHide()
-            ->render(function (Model $model) {
-                return $this->getTableActions($model)
-                    ->set('align', 'justify-content-end align-items-center')
-                    ->autoWidth()
-                    ->render();
-            }));
+        if($this->resource->isAddActions()){
+            $grid->push(TD::make(__('Actions'))
+                ->alignRight()
+                ->cantHide()
+                ->render(function (Model $model) {
+                    return $this->getTableActions($model)
+                        ->set('align', 'justify-content-end align-items-center')
+                        ->autoWidth()
+                        ->render();
+                }));
+        }
 
         return [
             Layout::selection($this->resource->filters()),


### PR DESCRIPTION
Sometimes the standard actions are not suitable for style and functionality. That's why I suggest hiding the standard actions.

By default, everything will work as before, but by predefining the isAddActions method in Resource and returning false, the actions will be hidden by default.

```
/**
* Should add actions?
*
* @return bool
*/
public function isAddActions(): bool
{
     return false;
}
```