### PR TITLE
Support for custom query, command bar, layouts, and more

### DIFF
--- a/routes/crud.php
+++ b/routes/crud.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
+use Orchid\Crud\Http\Controllers\AsyncController;
 use Orchid\Crud\ResourceRequest;
 use Orchid\Crud\Screens\CreateScreen;
 use Orchid\Crud\Screens\ViewScreen;
@@ -10,42 +11,49 @@ use Orchid\Crud\Screens\EditScreen;
 use Orchid\Crud\Screens\ListScreen;
 use Tabuna\Breadcrumbs\Trail;
 
-Route::screen('/crud/create/{resource?}', CreateScreen::class)
-    ->name('resource.create')
-    ->breadcrumbs(function (Trail $trail) {
-        $resource = app(ResourceRequest::class)->resource();
+Route::prefix(config('platform.crud_prefix', '/crud'))->group(
+    function () {
+        Route::screen('/create/{resource?}', CreateScreen::class)
+            ->name('resource.create')
+            ->breadcrumbs(function (Trail $trail) {
+                $resource = app(ResourceRequest::class)->resource();
 
-        return $trail
-            ->parent('platform.resource.list')
-            ->push($resource::createBreadcrumbsMessage());
-    });
+                return $trail
+                    ->parent('platform.resource.list')
+                    ->push($resource::createBreadcrumbsMessage());
+            });
 
-Route::screen('/crud/view/{resource?}/{id}', ViewScreen::class)
-    ->name('resource.view')
-    ->breadcrumbs(function (Trail $trail) {
-        $resource = app(ResourceRequest::class)->resource();
-        $id = request()->route('id');
+        Route::screen('/view/{resource?}/{id}', ViewScreen::class)
+            ->name('resource.view')
+            ->breadcrumbs(function (Trail $trail) {
+                $resource = app(ResourceRequest::class)->resource();
+                $id = request()->route('id');
 
-        return $trail
-            ->parent('platform.resource.list')
-            ->push(request()->route('id'), \route('platform.resource.view', [$resource::uriKey(), $id]));
-    });
+                return $trail
+                    ->parent('platform.resource.list')
+                    ->push(request()->route('id'), \route('platform.resource.view', [$resource::uriKey(), $id]));
+            });
 
-Route::screen('/crud/edit/{resource?}/{id}', EditScreen::class)
-    ->name('resource.edit')
-    ->breadcrumbs(function (Trail $trail, $name, $id) {
-        $resource = app(ResourceRequest::class)->resource();
+        Route::screen('/edit/{resource?}/{id}', EditScreen::class)
+            ->name('resource.edit')
+            ->breadcrumbs(function (Trail $trail, $name, $id) {
+                $resource = app(ResourceRequest::class)->resource();
 
-        return $trail
-            ->parent('platform.resource.view', [$name, $id])
-            ->push($resource::editBreadcrumbsMessage());
-    });
+                return $trail
+                    ->parent('platform.resource.view', [$name, $id])
+                    ->push($resource::editBreadcrumbsMessage());
+            });
 
-Route::screen('/crud/list/{resource?}', ListScreen::class)
-    ->name('resource.list')
-    ->breadcrumbs(function (Trail $trail) {
-        $resource = app(ResourceRequest::class)->resource();
+        Route::screen('/list/{resource?}', ListScreen::class)
+            ->name('resource.list')
+            ->breadcrumbs(function (Trail $trail) {
+                $resource = app(ResourceRequest::class)->resource();
 
-        return $trail->parent('platform.index')
-            ->push($resource::listBreadcrumbsMessage(), \route('platform.resource.list', [$resource::uriKey()]));
-    });
+                return $trail->parent('platform.index')
+                    ->push($resource::listBreadcrumbsMessage(), \route('platform.resource.list', [$resource::uriKey()]));
+            });
+    }
+);
+
+Route::post('/listener/{screen}/{layout}/{resource}/{id?}', [AsyncController::class, 'crudListener'])
+    ->name('async.listener.crud');

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -56,6 +56,28 @@ class CrudServiceProvider extends ServiceProvider
             }
         });
 
+        PlatformDashboard::macro('isCrudScreen', function (string $crudMethod, ?string $resourceName = null): bool {
+            return request()->routeIs('platform.resource.'.$crudMethod) && (
+                $resourceName ? request()->route('resource') === $resourceName : true
+            );
+        });
+
+        PlatformDashboard::macro('isCrudListScreen', function (?string $resourceName = null): bool {
+            return PlatformDashboard::isCrudScreen('list', $resourceName);
+        });
+
+        PlatformDashboard::macro('isCrudCreateScreen', function (?string $resourceName = null): bool {
+            return PlatformDashboard::isCrudScreen('create', $resourceName);
+        });
+
+        PlatformDashboard::macro('isCrudEditScreen', function (?string $resourceName = null): bool {
+            return PlatformDashboard::isCrudScreen('edit', $resourceName);
+        });
+
+        PlatformDashboard::macro('isCrudViewScreen', function (?string $resourceName = null): bool {
+            return PlatformDashboard::isCrudScreen('view', $resourceName);
+        });
+
         $resources = $finder
             ->setNamespace(app()->getNamespace() . 'Orchid\\Resources')
             ->find(app_path('Orchid/Resources'));

--- a/src/CrudServiceProvider.php
+++ b/src/CrudServiceProvider.php
@@ -6,6 +6,11 @@ use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Orchid\Crud\Commands\ActionCommand;
 use Orchid\Crud\Commands\ResourceCommand;
+use Orchid\Crud\Screens\CreateScreen;
+use Orchid\Crud\Screens\EditScreen;
+use Orchid\Crud\Screens\ListScreen;
+use Orchid\Crud\Screens\ViewScreen;
+use Orchid\Platform\Dashboard as PlatformDashboard;
 use Orchid\Platform\Providers\FoundationServiceProvider;
 use Orchid\Support\Facades\Dashboard;
 
@@ -35,6 +40,22 @@ class CrudServiceProvider extends ServiceProvider
      */
     public function boot(ResourceFinder $finder, Arbitrator $arbitrator): void
     {
+        PlatformDashboard::macro('getCrudScreenOperation', function (): string {
+            $currentScreen = Dashboard::getCurrentScreen();
+
+            if ($currentScreen) {
+                return match(true) {
+                    $currentScreen instanceof CreateScreen => 'create',
+                    $currentScreen instanceof EditScreen   => 'edit',
+                    $currentScreen instanceof ViewScreen   => 'view',
+                    $currentScreen instanceof ListScreen   => 'list',
+                    default                                => ''
+                };
+            } else {
+                return '';
+            }
+        });
+
         $resources = $finder
             ->setNamespace(app()->getNamespace() . 'Orchid\\Resources')
             ->find(app_path('Orchid/Resources'));

--- a/src/Exceptions/BehaviourChangers/ErrorHandledMessage.php
+++ b/src/Exceptions/BehaviourChangers/ErrorHandledMessage.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orchid\Crud\Exceptions\BehaviourChangers;
+
+class ErrorHandledMessage extends \Exception
+{
+}

--- a/src/Exceptions/BehaviourChangers/InfoMessageChanger.php
+++ b/src/Exceptions/BehaviourChangers/InfoMessageChanger.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Orchid\Crud\Exceptions\BehaviourChangers;
+
+class InfoMessageChanger extends \Exception
+{
+}

--- a/src/Exceptions/BehaviourChangers/RedirectTo.php
+++ b/src/Exceptions/BehaviourChangers/RedirectTo.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Orchid\Crud\Exceptions\BehaviourChangers;
+
+class RedirectTo extends \Exception
+{
+    protected string $redirectUrl;
+
+    protected ?string $toastMessage = null;
+
+    protected string $toastLevel = 'info';
+
+    public function __construct(string $redirectUrl)
+    {
+        $this->redirectUrl = $redirectUrl;
+    }
+
+    public function getRedirectUrl(): string
+    {
+        return $this->redirectUrl;
+    }
+
+    public static function forRoute($routeName, $routeParams = [], $absolute = true)
+    {
+        return new static(
+            route($routeName, $routeParams, $absolute)
+        );
+    }
+
+    public static function forUrl($redirectUrl)
+    {
+        return new static($redirectUrl);
+    }
+
+    public function getToastMessage(): ?string
+    {
+        return $this->toastMessage;
+    }
+
+    public function withToastMessage(?string $toastMessage): self
+    {
+        $this->toastMessage = $toastMessage;
+
+        return $this;
+    }
+
+    public function getToastLevel(): string
+    {
+        return $this->toastLevel;
+    }
+
+    public function withToastLevel(string $toastLevel): self
+    {
+        $allowedToastLevels = ['info', 'success', 'error', 'warning'];
+
+        if (in_array($toastLevel, $allowedToastLevels)) {
+            $this->toastLevel = $toastLevel;
+        } else {
+            throw new \Exception("{$toastLevel} not allowed");
+        }
+
+        return $this;
+    }
+}

--- a/src/Http/Controllers/AsyncController.php
+++ b/src/Http/Controllers/AsyncController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Orchid\Crud\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
+use Orchid\Crud\CrudScreen;
+use Orchid\Platform\Http\Controllers\AsyncController as OrchidAsyncController;
+
+class AsyncController extends OrchidAsyncController
+{
+    public function crudListener(Request $request, string $screen, string $layout, string $resource, ?string $id = null)
+    {
+        $screen = Crypt::decryptString($screen);
+        $layout = Crypt::decryptString($layout);
+        $resource = Crypt::decryptString($resource);
+        $id = $id ? Crypt::decryptString($id) : null;
+
+        // Fill the request resource and ID
+        $request->route()->setParameter('resource', $resource);
+        $request->route()->setParameter('id', $id);
+
+        // This allows us to use the same listener view without needing to copy it to this package
+        $request->route()->action['as'] = 'platform.async.listener';
+
+        /** @var \Orchid\Crud\CrudScreen $screen */
+        $screen = app($screen);
+
+        if (! $screen instanceof CrudScreen) {
+            return abort(500, 'Screen is not a CrudScreen');
+        }
+
+        // Boot middleware so it can fill the request and resource
+        foreach ($screen->getMiddleware() as $middlewareConfig) {
+            $screenMiddleware = $middlewareConfig['middleware'];
+
+            $screenMiddleware($request, function ($newRequest) use (&$request) {
+                $request = $newRequest;
+            });
+        }
+
+        /** @var \Orchid\Screen\Layouts\Listener $layout */
+        $layout = app($layout);
+
+        return $screen->asyncParticalLayout($layout, $request);
+    }
+}

--- a/src/Layouts/ResourceListener.php
+++ b/src/Layouts/ResourceListener.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Orchid\Crud\Layouts;
+
+use Illuminate\Support\Facades\Crypt;
+use Orchid\Crud\CrudScreen;
+use Orchid\Screen\Layouts\Listener;
+use Orchid\Support\Facades\Dashboard;
+
+abstract class ResourceListener extends Listener
+{
+    protected function asyncRoute(): ?string
+    {
+        $screen = Dashboard::getCurrentScreen();
+
+        if (! $screen) {
+            return null;
+        }
+
+        if ($screen instanceof CrudScreen) {
+            return route(
+                'platform.async.listener.crud',
+                array_filter(
+                    [
+                        'screen'   => Crypt::encryptString(get_class($screen)),
+                        'layout'   => Crypt::encryptString(static::class),
+                        'resource' => Crypt::encryptString(request()->route('resource')),
+                        'id'       => ($resourceId = request()->route('id')) ? Crypt::encryptString($resourceId) : null,
+                    ]
+                )
+            );
+        } else {
+            return route('platform.async.listener', [
+                'screen' => Crypt::encryptString(get_class($screen)),
+                'layout' => Crypt::encryptString(static::class),
+            ]);
+        }
+    }
+}

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -11,6 +11,29 @@ use Orchid\Screen\Field;
 use Orchid\Screen\Sight;
 use Orchid\Screen\TD;
 
+/**
+ * Resource is the basic representation of your model and custom logic for chosen screens.
+ *
+ * @method \Orchid\Screen\Layout[] customCreateLayout(\Orchid\Crud\Screens\CreateScreen $screen)                                               Overrides the default crud layout at the create screen. Use it when you only need to replace one part of the crud screens.
+ * @method \Orchid\Screen\Layout[] customEditLayout(\Orchid\Crud\Screens\EditScreen $screen)                                                   Overrides the default crud layout at the edit screen. Use it when you only need to replace one part of the crud screens.
+ * @method \Orchid\Screen\Layout[] customListLayout(\Orchid\Crud\Screens\ListScreen $screen)                                                   Overrides the default crud layout at the list screen. Use it when you only need to replace one part of the crud screens.
+ * @method \Orchid\Screen\Layout[] customViewLayout(\Orchid\Crud\Screens\ViewScreen $screen)                                                   Overrides the default crud layout at the view screen. Use it when you only need to replace one part of the crud screens.
+ * @method \Orchid\Screen\Action[] customCreateCommandBar(\Orchid\Crud\Screens\CreateScreen $screen)                                           Overrides the default command bar at the create screen
+ * @method \Orchid\Screen\Action[] customEditCommandBar(\Orchid\Crud\Screens\EditScreen $screen)                                               Overrides the default command bar at the edit screen
+ * @method \Orchid\Screen\Action[] customListCommandBar(\Orchid\Crud\Screens\ListScreen $screen)                                               Overrides the default command bar at the list screen
+ * @method \Orchid\Screen\Action[] customViewCommandBar(\Orchid\Crud\Screens\ViewScreen $screen)                                               Overrides the default command bar at the view screen
+ * @method array                   customViewQuery(\Orchid\Crud\Requests\ViewRequest $request, \Illuminate\Database\Eloquent\Model $model)     Use it to add extra data to the view screen. Acts like orchid Screen query method, merging the returned array to the CRUD query.
+ * @method array                   customListQuery(\Orchid\Crud\Requests\IndexRequest $request)                                                Use it to add extra data to the list screen. Acts like orchid Screen query method, merging the returned array to the CRUD query.
+ * @method array                   customCreateQuery(\Orchid\Crud\Requests\CreateRequest $request, \Illuminate\Database\Eloquent\Model $model) Use it to add extra data to the create screen. Acts like orchid Screen query method, merging the returned array to the CRUD query.
+ * @method array                   customEditQuery(\Orchid\Crud\Requests\UpdateRequest $request, \Illuminate\Database\Eloquent\Model $model)   Use it to add extra data to the edit screen. Acts like orchid Screen query method, merging the returned array to the CRUD query.
+ * @method string                  formRowTitle()                                                                                              Customize the form title at the Edit and Create screens
+ * @method \Orchid\Screen\Layout[] preFormLayout()                                                                                             Allows you to prepend extra form elements at the Edit and Create screens
+ * @method \Orchid\Screen\Layout[] postFormLayout()                                                                                            Allows you to append extra form elements at the Edit and Create screens
+ * @method void                    onSave(\Orchid\Crud\ResourceRequest $request, \Illuminate\Database\Eloquent\Model $model)
+ * @method void                    onDelete(\Illuminate\Database\Eloquent\Model $model)
+ * @method void                    onForceDelete(\Illuminate\Database\Eloquent\Model $model)
+ * @method void                    onRestore(\Illuminate\Database\Eloquent\Model $model)
+ */
 abstract class Resource
 {
     /**
@@ -19,6 +42,11 @@ abstract class Resource
      * @var string
      */
     public static $model = '';
+
+    /**
+     * If true it will redirect to the Crud View Resource page after saving the resource (create/update/restoring)
+     */
+    public static bool $redirectToViewAfterSaving = false;
 
     /**
      * Get the displayable label of the resource.

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -25,6 +25,11 @@ class ListScreen extends CrudScreen
     {
         return [
             'model' => $request->getModelPaginationList(),
+            ...(
+                method_exists($this->resource, 'customListQuery') ?
+                    $this->resource->customListQuery($request) :
+                    []
+            ),
         ];
     }
 
@@ -33,8 +38,12 @@ class ListScreen extends CrudScreen
      *
      * @return Action[]
      */
-    public function commandBar(): array
+    public function commandBar(bool $skipCustomCommandBar = false): array
     {
+        if (method_exists($this->resource, 'customListCommandBar') && ! $skipCustomCommandBar) {
+            return $this->resource->customListCommandBar($this);
+        }
+
         return [
             $this->actionsButtons(),
             Link::make($this->resource::createButtonLabel())
@@ -49,8 +58,16 @@ class ListScreen extends CrudScreen
      *
      * @return \Orchid\Screen\Layout[]
      */
-    public function layout(): array
+    public function layout(bool $skipCustomLayout = false): array
     {
+        /*
+        * We check if the `customListLayout` method exists,
+        * and allow you to recursively call this method passing the skipCustomLayout parameter.
+        */
+        if (method_exists($this->resource, 'customListLayout') && ! $skipCustomLayout) {
+            return $this->resource->customViewLayout($this);
+        }
+
         $grid = collect($this->resource->columns());
 
         $grid->prepend(TD::make()

--- a/src/Screens/ListScreen.php
+++ b/src/Screens/ListScreen.php
@@ -65,7 +65,7 @@ class ListScreen extends CrudScreen
         * and allow you to recursively call this method passing the skipCustomLayout parameter.
         */
         if (method_exists($this->resource, 'customListLayout') && ! $skipCustomLayout) {
-            return $this->resource->customViewLayout($this);
+            return $this->resource->customListLayout($this);
         }
 
         $grid = collect($this->resource->columns());

--- a/src/Screens/ViewScreen.php
+++ b/src/Screens/ViewScreen.php
@@ -31,6 +31,11 @@ class ViewScreen extends CrudScreen
 
         return [
             ResourceFields::PREFIX => $this->model,
+            ...(
+                method_exists($this->resource, 'customViewQuery') ?
+                    $this->resource->customViewQuery($request, $this->model) :
+                    []
+            ),
         ];
     }
 
@@ -39,8 +44,12 @@ class ViewScreen extends CrudScreen
      *
      * @return Action[]
      */
-    public function commandBar(): array
+    public function commandBar(bool $skipCustomCommandBar = false): array
     {
+        if (method_exists($this->resource, 'customViewCommandBar') && ! $skipCustomCommandBar) {
+            return $this->resource->customViewCommandBar($this);
+        }
+
         return [
             $this->actionsButtons(),
 
@@ -80,8 +89,16 @@ class ViewScreen extends CrudScreen
      *
      * @return \Orchid\Screen\Layout[]
      */
-    public function layout(): array
+    public function layout(bool $skipCustomLayout = false): array
     {
+        /*
+        * We check if the `customCreateLayout` method exists,
+        * and allow you to recursively call this method passing the skipCustomLayout parameter.
+        */
+        if (method_exists($this->resource, 'customViewLayout') && ! $skipCustomLayout) {
+            return $this->resource->customViewLayout($this);
+        }
+
         return [
             Layout::legend(ResourceFields::PREFIX, $this->resource->legend()),
         ];

--- a/stubs/resource.stub
+++ b/stubs/resource.stub
@@ -15,6 +15,11 @@ class {{ class }} extends Resource
     public static $model = {{ namespacedModel }};
 
     /**
+     * If true it will redirect to the Crud View Resource page after saving the resource (create/update/restoring)
+     */
+    public static bool $redirectToViewAfterSaving = false;
+
+    /**
      * Get the fields displayed by the resource.
      *
      * @return array


### PR DESCRIPTION
## Proposed Changes

  - Adds support for custom Orchid `query` methods for resources
  - Adds support for custom Crud Layouts for resources
  - Adds support for custom Command Bars for resources
  - Allows using Orchid Listeners within Crud, so you have dynamic layouts within your CRUDs
  - Adds a `formRowTitle` method to the resource, allowing you to set a custom title to the form layout
  - Adds custom Dashboard `getCrudScreenOperation` which allows you to understand what kind of operation you are executing at the time, this allows you to customize some actions and more.

## Motivation

Working with Orchid and Orchid Crud across some projects, I found that most of the time what I was doing was CRUD operations, yeah, we do have the occasional screen that is totally out of a form, but most of the operations were CRUD.

That led me to start adding more and more options to the CRUD, as everything is inside a resource, and the screens are "static" from Orchid/crud, I thought: "Why not add some customizations to parts of the screen that I need?", and that's why I started doing this and "copying" things project by project, which is inefficient, but, this allowed me to test different combinations.